### PR TITLE
Cr 763

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>test-framework</artifactId>
-      <version>0.0.11</version>
+      <version>0.0.12-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/uk/gov/ons/ctp/integration/common/product/ProductReference.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/common/product/ProductReference.java
@@ -95,7 +95,7 @@ public class ProductReference {
                         : p.getHandler().equals(example.getHandler()))
                     && (example.getIndividual() == null
                         ? true
-                        : p.getIndividual().equals(example.getIndividual()))
+                        : p.getIndividual() == example.getIndividual())
                     && (example.getLanguage() == null
                         ? true
                         : p.getLanguage().equals(example.getLanguage()))

--- a/src/main/java/uk/gov/ons/ctp/integration/common/product/model/Product.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/common/product/model/Product.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.integration.common.product.model;
 
+import java.util.Arrays;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,7 +33,16 @@ public class Product {
   public enum CaseType {
     HH,
     CE,
-    SPG
+    SPG;
+
+    /**
+     * toList is a convenience method to accommodate the change to casetypes now being an array
+     *
+     * @return a java.util.List containing just this CaseType
+     */
+    public List<CaseType> toList() {
+      return Arrays.asList(this);
+    }
   }
 
   public enum Handler {

--- a/src/test/java/uk/gov/ons/ctp/integration/common/product/CaseTypeTests.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/common/product/CaseTypeTests.java
@@ -2,7 +2,7 @@ package uk.gov.ons.ctp.integration.common.product;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static uk.gov.ons.ctp.integration.common.product.CustomAsserts.assertThrows;
+import static uk.gov.ons.ctp.common.utility.CustomAsserts.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/uk/gov/ons/ctp/integration/common/product/CaseTypeTests.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/common/product/CaseTypeTests.java
@@ -1,0 +1,30 @@
+package uk.gov.ons.ctp.integration.common.product;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static uk.gov.ons.ctp.integration.common.product.CustomAsserts.assertThrows;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import uk.gov.ons.ctp.integration.common.product.model.Product;
+
+public class CaseTypeTests {
+
+  @Test
+  public void toListReturnsASingletonList() {
+
+    Arrays.stream(Product.CaseType.values())
+        .forEach(
+            c -> {
+              List<Product.CaseType> list = c.toList();
+              assertEquals(1, list.size());
+              assertTrue(list.contains(c));
+              assertThrows(
+                  UnsupportedOperationException.class,
+                  () -> {
+                    list.add(Product.CaseType.CE);
+                  });
+            });
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/integration/common/product/ProductReferenceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/common/product/ProductReferenceTest.java
@@ -1,6 +1,6 @@
 package uk.gov.ons.ctp.integration.common.product;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,7 +34,7 @@ public abstract class ProductReferenceTest {
     assertTrue(products.size() > 0);
     for (Product p : products) {
       assertTrue(p.getCaseTypes().contains(CaseType.HH));
-      assertTrue(p.getIndividual().equals(false));
+      assertFalse(p.getIndividual());
     }
   }
 
@@ -134,7 +134,7 @@ public abstract class ProductReferenceTest {
     List<Product> products = productReference.searchProducts(example);
     assertTrue(products.size() > 0);
     for (Product p : products) {
-      assertTrue(p.getIndividual() == example.getIndividual());
+      assertEquals(p.getIndividual(), example.getIndividual());
     }
   }
 

--- a/src/test/java/uk/gov/ons/ctp/integration/common/product/ProductReferenceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/common/product/ProductReferenceTest.java
@@ -41,7 +41,7 @@ public abstract class ProductReferenceTest {
   @Test
   public void onlyHousehold() throws Exception {
     Product example = new Product();
-    example.setCaseTypes(Arrays.asList(CaseType.HH));
+    example.setCaseTypes(CaseType.HH.toList());
     List<Product> products = productReference.searchProducts(example);
     assertTrue(products.size() > 0);
     boolean indivFalse = false;


### PR DESCRIPTION
# Motivation and Context
We have changed CaseType to be an array. For convenience instances of the CaseTypes enum can now return a java.util.List containing themselves.

# What has changed
The CaseTypes enum has had a new method added to it. There are unit tests for this.

# How to test?
I wrote a unit test to iterate over each value and ensure it returned a List containing that, and only that enum.

# Links
[This PR](https://github.com/ONSdigital/census-int-common-test-framework/pull/6) added a new assert to allow testing of this.
